### PR TITLE
Changes made to particle driver using new struct

### DIFF
--- a/src/Zeitschleife.cs
+++ b/src/Zeitschleife.cs
@@ -44,9 +44,20 @@ namespace GRAL_2001
         public static void Calculate(int nteil)
         {
             //random number generator seeds
-            int rnd = (Environment.TickCount + nteil) & Int32.MaxValue;
-            uint m_w = (uint)(rnd + 521288629);
-            uint m_z = (uint)(rnd + 2232121);
+            uint m_w;
+            uint m_z;
+            if (Program.UseFixedRndSeedVal)
+            {
+                var seeds = new Program.ParticleRndSeeds((uint)nteil, (uint)Program.IWET);
+                m_w = seeds.Seed1;
+                m_z = seeds.Seed2;
+            }
+            else
+            {
+                int rnd = (Environment.TickCount + nteil) & Int32.MaxValue;
+                m_w = (uint)(rnd + 521288629);
+                m_z = (uint)(rnd + 2232121);
+            }
             
             float zahl1 = 0;
             uint u_rg = 0;


### PR DESCRIPTION
I have made changes to the particle driver using the new struct. The goal here is to use the Program.UseFixedRndSeedVal to determine if the new struct (fixed random numbers for deterministic model output) or the old method based on the Environment.TickCount should be used.

I am not sure if I have implemented this correctly or not, so any feedback or changes are welcome.