### PR TITLE
GRAL Deterministic Testing

### DIFF
--- a/src/ProgramDeclarations.cs
+++ b/src/ProgramDeclarations.cs
@@ -948,7 +948,7 @@ namespace GRAL_2001
         ///<summary>
         ///Particle random seeds
         ///</summary>
-        public static RandomGeneratorSeed RnGSeed = new RandomGeneratorSeed(1, 180, 2);
+        public static RandomGeneratorSeed RnGSeed = new RandomGeneratorSeed(1, 2, 180); //I switched these since I thought they were accidentially flipped.
         ///<summary>
         ///Deposition type 0 = no deposition, 1 = deposition+concentration, 2 = only deposition
         ///</summary>
@@ -1299,7 +1299,7 @@ namespace GRAL_2001
                 return (VelGasFact + 1).ToString(CultureInfo.InvariantCulture) + ", " + (VelPMxxFact + 1).ToString(CultureInfo.InvariantCulture);
             } 
         }
-        
+
         ///<summary>
         /// Random generator seeds for each particle
         ///</summary>
@@ -1311,10 +1311,11 @@ namespace GRAL_2001
             ///<summary>ParticleRndSeeds
             /// Set initial values
             ///</summary>
-            public RandomGeneratorSeed(int Situation, float WindDirection, float WindSpeed)
+            public RandomGeneratorSeed(int Situation, float WindSpeed, float WindDirection) //I flipped wind speed/direction
             {
-                Seed1 = 521288629 + Convert.ToUInt32(WindDirection + WindSpeed * 100) + (uint) (Situation << 2);
-                Seed2 = 2232121 + Convert.ToUInt32(WindDirection * 2) + (uint) (Situation << 1);
+                //Absolute value because wind direction was negative for a 270 degree wind for example
+                Seed1 = 521288629 + Convert.ToUInt32(Math.Abs(WindDirection) + WindSpeed * 100) + (uint)(Situation << 2);
+                Seed2 = 2232121 + Convert.ToUInt32(Math.Abs(WindDirection) * 2) + (uint)(Situation << 1);
                 if (Seed1 == 0)
                 {
                     Seed1 = 521288629;

--- a/src/U-prognostic-microscale_1.cs
+++ b/src/U-prognostic-microscale_1.cs
@@ -56,6 +56,7 @@ namespace GRAL_2001
             Vector<float> AREAxy_V = new Vector<float>(AREAxy);
             Vector<float> UG_V = new Vector<float>(UG);
             
+            //Does this need to be changed (and similar expressions in other files) to get deterministic results? Or does it not matter.
             int maxTasks = Math.Max(1, Program.IPROC + Math.Abs(Environment.TickCount % 8));
             int minL = Math.Min(64, Program.NII - 4); // Avoid too large slices due to perf issues
             Parallel.ForEach(Partitioner.Create(3, Program.NII, Math.Min(Math.Max(4, (Program.NII / maxTasks)), minL)), Program.pOptions, range =>


### PR DESCRIPTION
I have done testing by running GRAL 4 times with this branch. I ran it 2 times with the switch turned off and got different results between runs as expected. I ran it 2 more times with the switch turned on to get deterministic results, but I still got different results between runs unfortunately. I used 8 processors for all runs and only 1 weather situation.
See the attached in.dat (TXT to attach) input file below to see how I am using the switch based on the code in the ReadInDat.cs file. 1 is on, 0 is off.
[in.TXT](https://github.com/user-attachments/files/16327009/in.TXT)

Note that I have done testing just now with 1 processor, and there is still variability between models runs. So this issue may not entirely be related to multiple threads.
