### PR TITLE
Gral deterministic testing

### DIFF
--- a/src/Anfangko.cs
+++ b/src/Anfangko.cs
@@ -45,15 +45,9 @@ namespace GRAL_2001
 
             Parallel.For(1, Program.NTEILMAX + 1, Program.pOptions, nteil =>
             {
-                int seed = 0;
-                unchecked
-                {
-                    seed = nteil * Environment.TickCount;
-                }
-                Random Rng = new Random(seed);
-
+                
                 //random number generator seeds
-                double zuff1 = Rng.NextDouble();
+                double zuff1 = Random.Shared.NextDouble();
 
                 float AHint = 0;
 
@@ -95,11 +89,11 @@ namespace GRAL_2001
 
                             if (i > 0)
                             {
-                                zuff1 = Rng.NextDouble();
+                                zuff1 = Random.Shared.NextDouble();
 
                                 double radius = Program.PS_D[i] * 0.5 * zuff1;
 
-                                zuff1 = Rng.NextDouble();
+                                zuff1 = Random.Shared.NextDouble();
 
                                 double theta = 6.28 * zuff1;
                                 Program.Xcoord[nteil] = Program.PS_X[i] + radius * Math.Cos(theta);
@@ -188,11 +182,11 @@ namespace GRAL_2001
                             }
                             if (i > 0)
                             {
-                                zuff1 = Rng.NextDouble();
+                                zuff1 = Random.Shared.NextDouble();
 
                                 double zahl1 = Program.TS_Height[i] * zuff1;
 
-                                zuff1 = Rng.NextDouble();
+                                zuff1 = Random.Shared.NextDouble();
 
                                 double zahl2 = Program.TS_Width[i] * zuff1;
 
@@ -337,29 +331,29 @@ namespace GRAL_2001
                                 if (lang > 0.1)
                                 {
                                     // default case: horizontal line source 
-                                    zuff1 = Rng.NextDouble();
+                                    zuff1 = Random.Shared.NextDouble();
 
                                     double zahl0 = lang * zuff1;
                                     //noise abatement wall +1m
                                     if (Program.LS_Laerm[i] > 0)
                                     {
-                                        zuff1 = Rng.NextDouble();
+                                        zuff1 = Random.Shared.NextDouble();
 
                                         zahl1 = Program.LS_Laerm[i] + zuff1;
                                     }
                                     //user defined volume for initial mixing of particles (traffic induced turbulence)
                                     else if (Program.LS_Laerm[i] < 0)
                                     {
-                                        zuff1 = Rng.NextDouble();
+                                        zuff1 = Random.Shared.NextDouble();
                                         zahl1 = zuff1 * Math.Abs(Program.LS_Laerm[i]);
                                     }
                                     //standard initial mixing is up to 3m
                                     else if (Program.LS_Laerm[i] == 0)
                                     {
-                                        zuff1 = Rng.NextDouble();
+                                        zuff1 = Random.Shared.NextDouble();
                                         zahl1 = 3 * zuff1;
                                     }
-                                    zuff1 = Rng.NextDouble();
+                                    zuff1 = Random.Shared.NextDouble();
 
                                     double zahl2 = Program.LS_Width[i] * zuff1;
 
@@ -385,8 +379,8 @@ namespace GRAL_2001
                                     if (_vertExt < 0)
                                     {
                                         // use vertical extension as radius
-                                        Program.Xcoord[nteil] = Program.LS_X1[i] + (1 - Rng.NextDouble() * 2) * _vertExt; // (-1 to 1) * VertExt
-                                        Program.YCoord[nteil] = Program.LS_Y1[i] + (1 - Rng.NextDouble() * 2) * _vertExt; // (-1 to 1) * VertExt
+                                        Program.Xcoord[nteil] = Program.LS_X1[i] + (1 - Random.Shared.NextDouble() * 2) * _vertExt; // (-1 to 1) * VertExt
+                                        Program.YCoord[nteil] = Program.LS_Y1[i] + (1 - Random.Shared.NextDouble() * 2) * _vertExt; // (-1 to 1) * VertExt
                                     }
                                     else
                                     {
@@ -394,7 +388,7 @@ namespace GRAL_2001
                                         Program.Xcoord[nteil] = Program.LS_X1[i];
                                         Program.YCoord[nteil] = Program.LS_Y1[i];
                                     }
-                                    zuff1 = Rng.NextDouble();
+                                    zuff1 = Random.Shared.NextDouble();
                                     zzz = Program.LS_Z1[i] + (Program.LS_Z2[i] - Program.LS_Z1[i]) * zuff1;
                                 }
 
@@ -491,15 +485,15 @@ namespace GRAL_2001
                                     Program.ParticleVsed[nteil] = Program.AS_V_sed[i];
                                 }
 
-                                zuff1 = Rng.NextDouble();
+                                zuff1 = Random.Shared.NextDouble();
 
                                 double zahl0 = Program.AS_dX[i] * zuff1;
 
-                                zuff1 = Rng.NextDouble();
+                                zuff1 = Random.Shared.NextDouble();
 
                                 double zahl1 = Program.AS_dZ[i] * zuff1;
 
-                                zuff1 = Rng.NextDouble();
+                                zuff1 = Random.Shared.NextDouble();
                                 double zahl2 = Program.AS_dY[i] * zuff1;
 
                                 Program.Xcoord[nteil] = Program.AS_X[i] - Program.AS_dX[i] * 0.5F + zahl0;
@@ -560,7 +554,6 @@ namespace GRAL_2001
                             break;
                         }
                 }
-                Rng = null;
             });
 
             // Transient Mode: calculate average deposition settings for each source group one times (if Transient_Depo == null)

--- a/src/Anfangko.cs
+++ b/src/Anfangko.cs
@@ -17,6 +17,8 @@ namespace GRAL_2001
 {
     class StartCoordinates
     {
+        private const float RNG_Const = 2.328306435454494e-10F;
+        
         /// <summary>
         /// Calculate the start coordinates of all particles at a random point within the source geometries.
         /// Calculates the "mass" of each particle, depending on the emission rate of the source and the number of particles per source.
@@ -45,10 +47,17 @@ namespace GRAL_2001
 
             Parallel.For(1, Program.NTEILMAX + 1, Program.pOptions, nteil =>
             {
-                
                 //random number generator seeds
-                double zuff1 = Random.Shared.NextDouble();
-
+                int rnd = (Environment.TickCount + nteil) & Int32.MaxValue;
+                uint m_w = (uint)(rnd + 521288629);
+                uint m_z = (uint)(rnd + 2232121);
+                if (Program.UseFixedRndSeedVal)
+                {
+                    m_w = Program.RnGSeed.Seed1 + (uint)nteil;
+                    m_z = Program.RnGSeed.Seed2 + (uint)nteil * 2;
+                }
+                float zuff1 = DeterministicRng(ref m_z, ref m_w);
+                
                 float AHint = 0;
 
                 double sumanz = 0;
@@ -89,11 +98,11 @@ namespace GRAL_2001
 
                             if (i > 0)
                             {
-                                zuff1 = Random.Shared.NextDouble();
+                                zuff1 = DeterministicRng(ref m_z, ref m_w);
 
                                 double radius = Program.PS_D[i] * 0.5 * zuff1;
 
-                                zuff1 = Random.Shared.NextDouble();
+                                zuff1 = DeterministicRng(ref m_z, ref m_w);
 
                                 double theta = 6.28 * zuff1;
                                 Program.Xcoord[nteil] = Program.PS_X[i] + radius * Math.Cos(theta);
@@ -182,11 +191,11 @@ namespace GRAL_2001
                             }
                             if (i > 0)
                             {
-                                zuff1 = Random.Shared.NextDouble();
+                                zuff1 = DeterministicRng(ref m_z, ref m_w);
 
                                 double zahl1 = Program.TS_Height[i] * zuff1;
 
-                                zuff1 = Random.Shared.NextDouble();
+                                zuff1 = DeterministicRng(ref m_z, ref m_w);
 
                                 double zahl2 = Program.TS_Width[i] * zuff1;
 
@@ -331,29 +340,29 @@ namespace GRAL_2001
                                 if (lang > 0.1)
                                 {
                                     // default case: horizontal line source 
-                                    zuff1 = Random.Shared.NextDouble();
+                                    zuff1 = DeterministicRng(ref m_z, ref m_w);
 
                                     double zahl0 = lang * zuff1;
                                     //noise abatement wall +1m
                                     if (Program.LS_Laerm[i] > 0)
                                     {
-                                        zuff1 = Random.Shared.NextDouble();
+                                        zuff1 = DeterministicRng(ref m_z, ref m_w);
 
                                         zahl1 = Program.LS_Laerm[i] + zuff1;
                                     }
                                     //user defined volume for initial mixing of particles (traffic induced turbulence)
                                     else if (Program.LS_Laerm[i] < 0)
                                     {
-                                        zuff1 = Random.Shared.NextDouble();
+                                        zuff1 = DeterministicRng(ref m_z, ref m_w);
                                         zahl1 = zuff1 * Math.Abs(Program.LS_Laerm[i]);
                                     }
                                     //standard initial mixing is up to 3m
                                     else if (Program.LS_Laerm[i] == 0)
                                     {
-                                        zuff1 = Random.Shared.NextDouble();
+                                        zuff1 = DeterministicRng(ref m_z, ref m_w);
                                         zahl1 = 3 * zuff1;
                                     }
-                                    zuff1 = Random.Shared.NextDouble();
+                                    zuff1 = DeterministicRng(ref m_z, ref m_w);
 
                                     double zahl2 = Program.LS_Width[i] * zuff1;
 
@@ -379,8 +388,8 @@ namespace GRAL_2001
                                     if (_vertExt < 0)
                                     {
                                         // use vertical extension as radius
-                                        Program.Xcoord[nteil] = Program.LS_X1[i] + (1 - Random.Shared.NextDouble() * 2) * _vertExt; // (-1 to 1) * VertExt
-                                        Program.YCoord[nteil] = Program.LS_Y1[i] + (1 - Random.Shared.NextDouble() * 2) * _vertExt; // (-1 to 1) * VertExt
+                                        Program.Xcoord[nteil] = Program.LS_X1[i] + (1 - DeterministicRng(ref m_z, ref m_w) * 2) * _vertExt; // (-1 to 1) * VertExt
+                                        Program.YCoord[nteil] = Program.LS_Y1[i] + (1 - DeterministicRng(ref m_z, ref m_w) * 2) * _vertExt; // (-1 to 1) * VertExt
                                     }
                                     else
                                     {
@@ -388,7 +397,7 @@ namespace GRAL_2001
                                         Program.Xcoord[nteil] = Program.LS_X1[i];
                                         Program.YCoord[nteil] = Program.LS_Y1[i];
                                     }
-                                    zuff1 = Random.Shared.NextDouble();
+                                    zuff1 = DeterministicRng(ref m_z, ref m_w);
                                     zzz = Program.LS_Z1[i] + (Program.LS_Z2[i] - Program.LS_Z1[i]) * zuff1;
                                 }
 
@@ -485,15 +494,15 @@ namespace GRAL_2001
                                     Program.ParticleVsed[nteil] = Program.AS_V_sed[i];
                                 }
 
-                                zuff1 = Random.Shared.NextDouble();
+                                zuff1 = DeterministicRng(ref m_z, ref m_w);
 
                                 double zahl0 = Program.AS_dX[i] * zuff1;
 
-                                zuff1 = Random.Shared.NextDouble();
+                                zuff1 = DeterministicRng(ref m_z, ref m_w);
 
                                 double zahl1 = Program.AS_dZ[i] * zuff1;
 
-                                zuff1 = Random.Shared.NextDouble();
+                                zuff1 = DeterministicRng(ref m_z, ref m_w);
                                 double zahl2 = Program.AS_dY[i] * zuff1;
 
                                 Program.Xcoord[nteil] = Program.AS_X[i] - Program.AS_dX[i] * 0.5F + zahl0;
@@ -597,6 +606,13 @@ namespace GRAL_2001
                 }
             } // Transient Mode: average depo settings
 
+        }
+
+        public static float DeterministicRng(ref uint m_z, ref uint m_w)
+        {
+            m_z = 36969 * (m_z & 65535) + (m_z >> 16);
+            m_w = 18000 * (m_w & 65535) + (m_w >> 16);
+            return(((m_z << 16) + m_w + 1) * RNG_Const);
         }
     }
 }

--- a/src/GRAL.csproj
+++ b/src/GRAL.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
-    <VersionPrefix>24.04.1</VersionPrefix>
+    <VersionPrefix>24.11.1</VersionPrefix>
     <Authors>Dietmar Oettl;Markus Kuntner</Authors>
     <NeutralLanguage>en-US</NeutralLanguage>
     <AssemblyTitle>GRAL</AssemblyTitle>

--- a/src/Input_pgt.cs
+++ b/src/Input_pgt.cs
@@ -73,8 +73,17 @@ namespace GRAL_2001
                     //random wind direction taken from the defined sector width
                     if ((TIMESERIES == "0") && (Program.Topo != Consts.TerrainAvailable))
                     {
-                        Random rnd = new Random();
-                        Program.WindDirGral = Program.WindDirGral - (float)(SECTORWIDTH / 20) + (float)(rnd.NextDouble() * SECTORWIDTH / 10);
+                        float rngVal = (float) Random.Shared.NextDouble();
+                        if (Program.UseFixedRndSeedVal)
+                        {
+                            Program.RandomGeneratorSeed rnGSeed = new Program.RandomGeneratorSeed(Program.IWET, Program.WindDirGral, Program.WindVelGral);
+                            uint m_w = Program.RnGSeed.Seed1;
+                            uint m_z = Program.RnGSeed.Seed2;
+                            m_z = 36969 * (m_z & 65535) + (m_z >> 16);
+                            m_w = 18000 * (m_w & 65535) + (m_w >> 16);
+                            rngVal = ((m_z << 16) + m_w + 1) * 2.328306435454494e-10F;
+                        }
+                        Program.WindDirGral = Program.WindDirGral - (float)(SECTORWIDTH / 20) + (float)(rngVal * SECTORWIDTH / 10);
                     }
 
                     //horizontal wind components

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -626,6 +626,8 @@ namespace GRAL_2001
                         ProgramWriters.LogfileGralCoreWrite(Info);
                     }
 
+                    RnGSeed = new RandomGeneratorSeed(IWET, WindVelGral, WindDirGral);
+
                     //calculating momentum and bouyancy forces for point sources
                     PointSourceHeight.CalculatePointSourceHeight();
 

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -66,7 +66,7 @@ namespace GRAL_2001
             Console.WriteLine("");
             Console.WriteLine("+------------------------------------------------------+");
             Console.WriteLine("|                                                      |");
-            string Info =     "+  > >         G R A L VERSION: 24.04            < <   +";
+            string Info =     "+  > >         G R A L VERSION: 24.11Beta1       < <   +";
             Console.WriteLine(Info);
             if (RunOnUnix)
             {

--- a/src/ProgramDeclarations.cs
+++ b/src/ProgramDeclarations.cs
@@ -1311,10 +1311,10 @@ namespace GRAL_2001
             ///<summary>ParticleRndSeeds
             /// Set initial values
             ///</summary>
-            public RandomGeneratorSeed(uint Situation, float WindDirection, float WindSpeed)
+            public RandomGeneratorSeed(int Situation, float WindDirection, float WindSpeed)
             {
-                Seed1 = 521288629 + Convert.ToUInt32(WindDirection + WindSpeed * 100) + (Situation << 2);
-                Seed2 = 2232121 + Convert.ToUInt32(WindDirection * 2) + (Situation << 1);
+                Seed1 = 521288629 + Convert.ToUInt32(WindDirection + WindSpeed * 100) + (uint) (Situation << 2);
+                Seed2 = 2232121 + Convert.ToUInt32(WindDirection * 2) + (uint) (Situation << 1);
                 if (Seed1 == 0)
                 {
                     Seed1 = 521288629;

--- a/src/ProgramDeclarations.cs
+++ b/src/ProgramDeclarations.cs
@@ -946,6 +946,10 @@ namespace GRAL_2001
         ///</summary>
         public static float[] ParticleVdep = new float[1];
         ///<summary>
+        ///Particle random seeds
+        ///</summary>
+        public static ParticleRndSeeds[] ParticleRnd = new ParticleRndSeeds [1];
+        ///<summary>
         ///Deposition type 0 = no deposition, 1 = deposition+concentration, 2 = only deposition
         ///</summary>
         public static byte[] ParticleMode = new byte[1];
@@ -1294,6 +1298,29 @@ namespace GRAL_2001
             {
                 return (VelGasFact + 1).ToString(CultureInfo.InvariantCulture) + ", " + (VelPMxxFact + 1).ToString(CultureInfo.InvariantCulture);
             } 
+        }
+        
+        ///<summary>
+        /// Random generator seeds for each particle
+        ///</summary>
+        /// <param name="Situation">Recent situation</param>
+        /// <param name="Number">Recent particle number</param>
+        public readonly struct ParticleRndSeeds
+        {
+            public ParticleRndSeeds(uint Situation, uint Number)
+            {
+                Seed1 = 23445 + Number + (Situation << 2);
+                Seed2 = 129983 + (Number << 1) + (Situation << 1);
+            }
+            ///<summary>
+            /// Seed 1
+            ///</summary>
+            public uint Seed1 { get; }
+
+            ///<summary>
+            /// Seed 2
+            ///</summary>
+            public uint Seed2 { get; }
         }
     }
 }

--- a/src/ProgramDeclarations.cs
+++ b/src/ProgramDeclarations.cs
@@ -948,7 +948,7 @@ namespace GRAL_2001
         ///<summary>
         ///Particle random seeds
         ///</summary>
-        public static ParticleRndSeeds[] ParticleRnd = new ParticleRndSeeds [1];
+        public static RandomGeneratorSeed RnGSeed = new RandomGeneratorSeed(1, 180, 2);
         ///<summary>
         ///Deposition type 0 = no deposition, 1 = deposition+concentration, 2 = only deposition
         ///</summary>
@@ -1304,13 +1304,25 @@ namespace GRAL_2001
         /// Random generator seeds for each particle
         ///</summary>
         /// <param name="Situation">Recent situation</param>
-        /// <param name="Number">Recent particle number</param>
-        public readonly struct ParticleRndSeeds
+        /// <param name="WindDirection">Recent wind direction</param>
+        /// <param name="WindSpeed">Recent wind speed</param>
+        public readonly struct RandomGeneratorSeed
         {
-            public ParticleRndSeeds(uint Situation, uint Number)
+            ///<summary>ParticleRndSeeds
+            /// Set initial values
+            ///</summary>
+            public RandomGeneratorSeed(uint Situation, float WindDirection, float WindSpeed)
             {
-                Seed1 = 23445 + Number + (Situation << 2);
-                Seed2 = 129983 + (Number << 1) + (Situation << 1);
+                Seed1 = 521288629 + Convert.ToUInt32(WindDirection + WindSpeed * 100) + (Situation << 2);
+                Seed2 = 2232121 + Convert.ToUInt32(WindDirection * 2) + (Situation << 1);
+                if (Seed1 == 0)
+                {
+                    Seed1 = 521288629;
+                }
+                if (Seed2 == 0)
+                {
+                    Seed2 = 2232121;
+                }
             }
             ///<summary>
             /// Seed 1

--- a/src/ProgramDeclarations.cs
+++ b/src/ProgramDeclarations.cs
@@ -948,7 +948,7 @@ namespace GRAL_2001
         ///<summary>
         ///Particle random seeds
         ///</summary>
-        public static RandomGeneratorSeed RnGSeed = new RandomGeneratorSeed(1, 180, 2);
+        public static RandomGeneratorSeed RnGSeed = new RandomGeneratorSeed(1, 2, 180); //I switched these since I thought they were accidentially flipped.
         ///<summary>
         ///Deposition type 0 = no deposition, 1 = deposition+concentration, 2 = only deposition
         ///</summary>
@@ -1299,7 +1299,7 @@ namespace GRAL_2001
                 return (VelGasFact + 1).ToString(CultureInfo.InvariantCulture) + ", " + (VelPMxxFact + 1).ToString(CultureInfo.InvariantCulture);
             } 
         }
-        
+
         ///<summary>
         /// Random generator seeds for each particle
         ///</summary>
@@ -1311,10 +1311,11 @@ namespace GRAL_2001
             ///<summary>ParticleRndSeeds
             /// Set initial values
             ///</summary>
-            public RandomGeneratorSeed(int Situation, float WindDirection, float WindSpeed)
+            public RandomGeneratorSeed(int Situation, float WindSpeed, float WindDirection) //I flipped wind speed/direction
             {
-                Seed1 = 521288629 + Convert.ToUInt32(WindDirection + WindSpeed * 100) + (uint) (Situation << 2);
-                Seed2 = 2232121 + Convert.ToUInt32(WindDirection * 2) + (uint) (Situation << 1);
+                //Absolute value because wind direction was negative for a 270 degree wind for example
+                Seed1 = 521288629 + Convert.ToUInt32(Math.Abs(WindDirection) + WindSpeed * 100) + (uint)(Situation << 2);
+                Seed2 = 2232121 + Convert.ToUInt32(Math.Abs(WindDirection) * 2) + (uint)(Situation << 1);
                 if (Seed1 == 0)
                 {
                     Seed1 = 521288629;

--- a/src/ProgramDeclarations.cs
+++ b/src/ProgramDeclarations.cs
@@ -1262,6 +1262,11 @@ namespace GRAL_2001
         public static bool UseVector512Class = false;
 
         ///<summary>
+        /// Use Fixed Random Seed Value?
+        ///</summary>
+        public static bool UseFixedRndSeedVal = false;
+
+        ///<summary>
         /// Deposition velocity factor within vegetation areas
         ///</summary>
         public readonly struct VegetationDepoVel

--- a/src/ProgramFunctions.cs
+++ b/src/ProgramFunctions.cs
@@ -1250,18 +1250,5 @@ namespace GRAL_2001
             // }
             // SB = null;
         }
-        
-        /// <summary>
-        /// Generate the vertical Grid for GRAL calculations for flat terrain
-        /// </summary>
-        /// /// <param name="Situations">Recent situation</param>
-        public static void GenerateRandomSeeds(int Situations)
-        {
-            uint sit = (uint) Situations;
-            for (uint i = (uint) Program.ParticleRnd.Length - 1; i >= 0; i--)
-            {
-                Program.ParticleRnd[i] = new Program.ParticleRndSeeds(sit, i);
-            }
-        }
     }
 }

--- a/src/ProgramFunctions.cs
+++ b/src/ProgramFunctions.cs
@@ -1250,6 +1250,18 @@ namespace GRAL_2001
             // }
             // SB = null;
         }
-
+        
+        /// <summary>
+        /// Generate the vertical Grid for GRAL calculations for flat terrain
+        /// </summary>
+        /// /// <param name="Situations">Recent situation</param>
+        public static void GenerateRandomSeeds(int Situations)
+        {
+            uint sit = (uint) Situations;
+            for (uint i = (uint) Program.ParticleRnd.Length - 1; i >= 0; i--)
+            {
+                Program.ParticleRnd[i] = new Program.ParticleRndSeeds(sit, i);
+            }
+        }
     }
 }

--- a/src/ReadInDat.cs
+++ b/src/ReadInDat.cs
@@ -267,6 +267,25 @@ namespace GRAL_2001
                                 { }
                             }
 
+                            // Use fixed random seed value
+                            if (sr.EndOfStream == false)
+                            {
+                                try
+                                {
+                                    _line++;
+                                    text = sr.ReadLine().Split(new char[] { ' ', ',', '\r', '\n', ';', '!' }, StringSplitOptions.RemoveEmptyEntries);
+                                    if (text.Length > 0 && int.TryParse(text[0], System.Globalization.NumberStyles.Any, ic, out int r))
+                                    {
+                                        if (r == 1) //1: Use fixed random seed value
+                                        {
+                                            Program.UseFixedRndSeedVal = true;
+                                        }
+                                    }
+                                }
+                                catch
+                                { }
+                            }
+
                         }
                     }
                 }

--- a/src/U-prognostic-microscale_1.cs
+++ b/src/U-prognostic-microscale_1.cs
@@ -56,6 +56,7 @@ namespace GRAL_2001
             Vector<float> AREAxy_V = new Vector<float>(AREAxy);
             Vector<float> UG_V = new Vector<float>(UG);
             
+            //Does this need to be changed (and similar expressions in other files) to get deterministic results? Or does it not matter.
             int maxTasks = Math.Max(1, Program.IPROC + Math.Abs(Environment.TickCount % 8));
             int minL = Math.Min(64, Program.NII - 4); // Avoid too large slices due to perf issues
             Parallel.ForEach(Partitioner.Create(3, Program.NII, Math.Min(Math.Max(4, (Program.NII / maxTasks)), minL)), Program.pOptions, range =>

--- a/src/Zeitschleife.cs
+++ b/src/Zeitschleife.cs
@@ -47,7 +47,12 @@ namespace GRAL_2001
             int rnd = (Environment.TickCount + nteil) & Int32.MaxValue;
             uint m_w = (uint)(rnd + 521288629);
             uint m_z = (uint)(rnd + 2232121);
-            
+            if (Program.UseFixedRndSeedVal)
+            {
+                m_w = Program.RnGSeed.Seed1 + (uint)nteil;
+                m_z = Program.RnGSeed.Seed2 + (uint)nteil * 2;
+            }
+
             float zahl1 = 0;
             uint u_rg = 0;
             float u1_rg = 0;

--- a/src/Zeitschleife_nonsteadystate.cs
+++ b/src/Zeitschleife_nonsteadystate.cs
@@ -75,9 +75,14 @@ namespace GRAL_2001
         private static void ParticleDriver(int i, int j, int k, int SG, float TransConcentration)
         {
             //random number generator seeds
-            int rnd = (Environment.TickCount + i + j) & Int32.MaxValue ;
+            int rnd = (Environment.TickCount + i + j) & Int32.MaxValue;
             uint m_w = (uint)(rnd + 521288629);
-            uint m_z = (uint)(rnd + 2232121);            
+            uint m_z = (uint)(rnd + 2232121);
+            if (Program.UseFixedRndSeedVal)
+            {
+                m_w = Program.RnGSeed.Seed1 + (uint)(i + j);
+                m_z = Program.RnGSeed.Seed2 + (uint)(i * 2);
+            }
             float zahl1 = 0;
             uint u_rg = 0;
             float u1_rg = 0;


### PR DESCRIPTION
The GRAL dispersion calculation is deterministic now.
The flow field calculation is not yet deterministic. There are several solutions:

- For calculations with only one processor core, the flow field calculation is already deterministic
- One calculates *.gff files and carries out the calculations with these *.gff files. Then the calculation is also deterministic
- The flow field calculation is revised, which is not an easy task

Why is the flow field calculation not deterministic?
The calculation must, in principle, be processed sequentially. Parallelization is performed in such a way that stripes with different widths are calculated sequentially, but the stripes are calculated in parallel in an unknown order. This leads to numerical errors at the intersections, which vary depending on the Task Parallel Library (TPL). The differences are small, but are sufficient for the results not to be deterministic.
This can only be solved if you use a different solver or use the TPL instead of Parallel.ForEach or previously even Parallel.For . The TPL can be used to control parallelization so that a deterministic result would be possible, at least with a constant number of processor cores. 