### PR TITLE
Random gen suggestions

### DIFF
--- a/src/GFFRead.cs
+++ b/src/GFFRead.cs
@@ -243,7 +243,7 @@ namespace GRAL_2001
 
                             readData = reader.ReadBytes((Program.NJJ + 1) * 6); // read one vertical column 
                             int offset = (Program.NJJ + 1) * 2;
-                            Parallel.For(1, Program.NJJ + 1, Program.pOptions, j =>
+                            Parallel.For(1, Program.NJJ + 2, Program.pOptions, j =>
                             {
                                 int index = (j - 1) * 2;
                                 UK_L[j][k - 1] = (float)((Int16)(readData[index] | (readData[index + 1] << 8))) * 0.01F; // 19.06.03 Ku: use Bitshift instead of Bitconverter 2 Bytes  = word integer value

--- a/src/PrognosticFlowfield.cs
+++ b/src/PrognosticFlowfield.cs
@@ -1044,25 +1044,40 @@ namespace GRAL_2001
                 //algebraic mixing length model
                 if (TurbulenceModel == 1)
                 {
-                    Program.pOptions.MaxDegreeOfParallelism += 2;
-
                     if (Program.UseVector512Class)
                     {
-                        Parallel.Invoke(Program.pOptions,
+                        if (!Program.UseFixedRndSeedVal)
+                        {
+                            Program.pOptions.MaxDegreeOfParallelism += 2;
+                            Parallel.Invoke(Program.pOptions,
                             () => U_PrognosticMicroscaleV1_Vec512.Calculate(IS, JS, Cmueh, VISHMIN, AREAxy, UG, relax),
                             () => V_PrognosticMicroscaleV1_Vec512.Calculate(-IS, -JS, Cmueh, VISHMIN, AREAxy, VG, relax));
+                            Program.pOptions.MaxDegreeOfParallelism -= 2;
+                        }
+                        else
+                        {
+                            U_PrognosticMicroscaleV1_Vec512.Calculate(IS, JS, Cmueh, VISHMIN, AREAxy, UG, relax);
+                            V_PrognosticMicroscaleV1_Vec512.Calculate(-IS, -JS, Cmueh, VISHMIN, AREAxy, VG, relax);
+                        }
                         W_PrognosticMicroscaleV1_Vec512.Calculate(IS, JS, Cmueh, VISHMIN, AREAxy, relax);
                     }
                     else
                     {
-                        Parallel.Invoke(Program.pOptions,
+                        if (!Program.UseFixedRndSeedVal)
+                        {
+                            Program.pOptions.MaxDegreeOfParallelism += 2;
+                            Parallel.Invoke(Program.pOptions,
                             () => U_PrognosticMicroscaleV1.Calculate(IS, JS, Cmueh, VISHMIN, AREAxy, UG, relax),
                             () => V_PrognosticMicroscaleV1.Calculate(-IS, -JS, Cmueh, VISHMIN, AREAxy, VG, relax));
-                        // U_PrognosticMicroscaleV1.Calculate(IS, JS, Cmueh, VISHMIN, AREAxy, UG, relax);
-                        // V_PrognosticMicroscaleV1.Calculate(-IS, -JS, Cmueh, VISHMIN, AREAxy, VG, relax);
+                            Program.pOptions.MaxDegreeOfParallelism -= 2;
+                        }
+                        else
+                        {
+                            U_PrognosticMicroscaleV1.Calculate(IS, JS, Cmueh, VISHMIN, AREAxy, UG, relax);
+                            V_PrognosticMicroscaleV1.Calculate(-IS, -JS, Cmueh, VISHMIN, AREAxy, VG, relax);
+                        }
                         W_PrognosticMicroscaleV1.Calculate(IS, JS, Cmueh, VISHMIN, AREAxy, relax);
                     }
-                    Program.pOptions.MaxDegreeOfParallelism -= 2;
                 }
 
                 //k-eps model

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -297,6 +297,13 @@ namespace GRAL_2001
                 AdaptiveRoughnessMax = 0;
             }
 
+            if (Program.UseFixedRndSeedVal)
+            {
+                Info = "GRAL Deterministic Mode";
+                Console.WriteLine(Info);
+                ProgramWriters.LogfileGralCoreWrite(Info);
+            }
+
             //setting the lateral borders of the domain -> Attention: changes the GRAL borders from absolute to relative values!
             InitGralBorders();
 


### PR DESCRIPTION
The GRAL dispersion calculation is deterministic now.
The flow field calculation is not yet deterministic. There are several solutions:

    For calculations with only one processor core, the flow field calculation is already deterministic
    One calculates *.gff files and carries out the calculations with these *.gff files. Then the calculation is also deterministic
    The flow field calculation is revised, which is not an easy task

Why is the flow field calculation not deterministic?
The calculation must, in principle, be processed sequentially. Parallelization is performed in such a way that stripes with different widths are calculated sequentially, but the stripes are calculated in parallel in an unknown order. This leads to numerical errors at the intersections, which vary depending on the Task Parallel Library (TPL). The differences are small, but are sufficient for the results not to be deterministic.
This can only be solved if you use a different solver or use the TPL instead of Parallel.ForEach or previously even Parallel.For . The TPL can be used to control parallelization so that a deterministic result would be possible, at least with a constant number of processor cores.
